### PR TITLE
Added ID to VJS-Selected

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -23,9 +23,11 @@ const defaults = {
 // so it won't conflict with `vjs-icon-play
 // since it'll get added when we mouse out
 const addSelectedClass = function(el) {
+  el.setAttribute('id', 'vjs-selected');
   el.addClass('vjs-selected');
 };
 const removeSelectedClass = function(el) {
+  el.removeAttribute('id', 'vjs-selected');
   el.removeClass('vjs-selected');
 
   if (el.thumbnail) {


### PR DESCRIPTION
## Description
In the `vjs-playlist` it's nice that that single element has a class added to it, but it would be helpful if it also had and ID attribute.  There will always only be one, and it is easier to hook into it to move or animate the currenty playing video to the top of the list.

## Specific Changes proposed
I just added and removed the ID alongside the class.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
