### PR TITLE
feat: convert the plugin to a class-based plugin

### DIFF
--- a/src/playlist-menu-item.js
+++ b/src/playlist-menu-item.js
@@ -1,0 +1,177 @@
+import document from 'global/document';
+import videojs from 'video.js';
+
+const Component = videojs.getComponent('Component');
+
+const createThumbnail = function(thumbnail) {
+  if (!thumbnail) {
+    const placeholder = document.createElement('div');
+
+    placeholder.className = 'vjs-playlist-thumbnail vjs-playlist-thumbnail-placeholder';
+    return placeholder;
+  }
+
+  const picture = document.createElement('picture');
+
+  picture.className = 'vjs-playlist-thumbnail';
+
+  if (typeof thumbnail === 'string') {
+    // simple thumbnails
+    const img = document.createElement('img');
+
+    img.loading = 'lazy';
+    img.src = thumbnail;
+    img.alt = '';
+    picture.appendChild(img);
+  } else {
+    // responsive thumbnails
+
+    // additional variations of a <picture> are specified as
+    // <source> elements
+    for (let i = 0; i < thumbnail.length - 1; i++) {
+      const variant = thumbnail[i];
+      const source = document.createElement('source');
+
+      // transfer the properties of each variant onto a <source>
+      for (const prop in variant) {
+        source[prop] = variant[prop];
+      }
+      picture.appendChild(source);
+    }
+
+    // the default version of a <picture> is specified by an <img>
+    const variant = thumbnail[thumbnail.length - 1];
+    const img = document.createElement('img');
+
+    img.loading = 'lazy';
+    img.alt = '';
+    for (const prop in variant) {
+      img[prop] = variant[prop];
+    }
+    picture.appendChild(img);
+  }
+  return picture;
+};
+
+class PlaylistMenuItem extends Component {
+
+  constructor(player, playlistItem, settings) {
+    if (!playlistItem.item) {
+      throw new Error('Cannot construct a PlaylistMenuItem without an item option');
+    }
+
+    playlistItem.showDescription = settings.showDescription;
+    super(player, playlistItem);
+    this.item = playlistItem.item;
+
+    this.playOnSelect = settings.playOnSelect;
+
+    this.emitTapEvents();
+
+    this.on(['click', 'tap'], this.switchPlaylistItem_);
+    this.on('keydown', this.handleKeyDown_);
+
+  }
+
+  handleKeyDown_(event) {
+    // keycode 13 is <Enter>
+    // keycode 32 is <Space>
+    if (event.which === 13 || event.which === 32) {
+      this.switchPlaylistItem_();
+    }
+  }
+
+  switchPlaylistItem_(event) {
+    this.player_.playlist.currentItem(this.player_.playlist().indexOf(this.item));
+    if (this.playOnSelect) {
+      this.player_.play();
+    }
+  }
+
+  createEl() {
+    const li = document.createElement('li');
+    const item = this.options_.item;
+    const showDescription = this.options_.showDescription;
+
+    if (typeof item.data === 'object') {
+      const dataKeys = Object.keys(item.data);
+
+      dataKeys.forEach(key => {
+        const value = item.data[key];
+
+        li.dataset[key] = value;
+      });
+    }
+
+    li.className = 'vjs-playlist-item';
+    li.setAttribute('tabIndex', 0);
+
+    // Thumbnail image
+    this.thumbnail = createThumbnail(item.thumbnail);
+    li.appendChild(this.thumbnail);
+
+    // Duration
+    if (item.duration) {
+      const duration = document.createElement('time');
+      const time = videojs.time.formatTime(item.duration);
+
+      duration.className = 'vjs-playlist-duration';
+      duration.setAttribute('datetime', 'PT0H0M' + item.duration + 'S');
+      duration.appendChild(document.createTextNode(time));
+      li.appendChild(duration);
+    }
+
+    // Now playing
+    const nowPlayingEl = document.createElement('span');
+    const nowPlayingText = this.localize('Now Playing');
+
+    nowPlayingEl.className = 'vjs-playlist-now-playing-text';
+    nowPlayingEl.appendChild(document.createTextNode(nowPlayingText));
+    nowPlayingEl.setAttribute('title', nowPlayingText);
+    this.thumbnail.appendChild(nowPlayingEl);
+
+    // Title container contains title and "up next"
+    const titleContainerEl = document.createElement('div');
+
+    titleContainerEl.className = 'vjs-playlist-title-container';
+    this.thumbnail.appendChild(titleContainerEl);
+
+    // Up next
+    const upNextEl = document.createElement('span');
+    const upNextText = this.localize('Up Next');
+
+    upNextEl.className = 'vjs-up-next-text';
+    upNextEl.appendChild(document.createTextNode(upNextText));
+    upNextEl.setAttribute('title', upNextText);
+    titleContainerEl.appendChild(upNextEl);
+
+    // Video title
+    const titleEl = document.createElement('cite');
+    const titleText = item.name || this.localize('Untitled Video');
+
+    titleEl.className = 'vjs-playlist-name';
+    titleEl.appendChild(document.createTextNode(titleText));
+    titleEl.setAttribute('title', titleText);
+    titleContainerEl.appendChild(titleEl);
+
+    // Populate thumbnails alt with the video title
+    this.thumbnail.getElementsByTagName('img').alt = titleText;
+
+    // We add thumbnail video description only if specified in playlist options
+    if (showDescription) {
+      const descriptionEl = document.createElement('div');
+      const descriptionText = item.description || '';
+
+      descriptionEl.className = 'vjs-playlist-description';
+      descriptionEl.appendChild(document.createTextNode(descriptionText));
+      descriptionEl.setAttribute('title', descriptionText);
+      titleContainerEl.appendChild(descriptionEl);
+    }
+
+    return li;
+  }
+}
+
+videojs.registerComponent('PlaylistMenuItem', PlaylistMenuItem);
+
+export default PlaylistMenuItem;

--- a/src/playlist-menu.js
+++ b/src/playlist-menu.js
@@ -1,0 +1,193 @@
+import document from 'global/document';
+import videojs from 'video.js';
+import PlaylistMenuItem from './playlist-menu-item';
+
+// we don't add `vjs-playlist-now-playing` in addSelectedClass
+// so it won't conflict with `vjs-icon-play
+// since it'll get added when we mouse out
+const addSelectedClass = function(el) {
+  el.addClass('vjs-selected');
+};
+const removeSelectedClass = function(el) {
+  el.removeClass('vjs-selected');
+
+  if (el.thumbnail) {
+    videojs.dom.removeClass(el.thumbnail, 'vjs-playlist-now-playing');
+  }
+};
+
+const upNext = function(el) {
+  el.addClass('vjs-up-next');
+};
+
+const notUpNext = function(el) {
+  el.removeClass('vjs-up-next');
+};
+
+const Component = videojs.getComponent('Component');
+
+class PlaylistMenu extends Component {
+
+  constructor(player, options) {
+    super(player, options);
+    this.items = [];
+
+    if (options.horizontal) {
+      this.addClass('vjs-playlist-horizontal');
+    } else {
+      this.addClass('vjs-playlist-vertical');
+    }
+
+    // If CSS pointer events aren't supported, we have to prevent
+    // clicking on playlist items during ads with slightly more
+    // invasive techniques. Details in the stylesheet.
+    if (options.supportsCssPointerEvents) {
+      this.addClass('vjs-csspointerevents');
+    }
+
+    this.createPlaylist_();
+
+    if (!videojs.browser.TOUCH_ENABLED) {
+      this.addClass('vjs-mouse');
+    }
+
+    this.on(player, ['loadstart', 'playlistchange', 'playlistsorted'], (e) => {
+
+      // The playlistadd and playlistremove events are handled separately. These
+      // also fire the playlistchange event with an `action` property, so can
+      // exclude them here.
+      if (e.type === 'playlistchange' && ['add', 'remove'].includes(e.action)) {
+        return;
+      }
+      this.update();
+    });
+
+    this.on(player, ['playlistadd', 'playlistremove'], (e) => {
+
+    });
+
+    // Keep track of whether an ad is playing so that the menu
+    // appearance can be adapted appropriately
+    this.on(player, 'adstart', () => {
+      this.addClass('vjs-ad-playing');
+    });
+
+    this.on(player, 'adend', () => {
+      this.removeClass('vjs-ad-playing');
+    });
+
+    this.on('dispose', () => {
+      this.empty_();
+      player.playlistMenu = null;
+    });
+
+    this.on(player, 'dispose', () => {
+      this.dispose();
+    });
+  }
+
+  createEl() {
+    return videojs.dom.createEl('div', {className: this.options_.className});
+  }
+
+  empty_() {
+    if (this.items && this.items.length) {
+      this.items.forEach(i => i.dispose());
+      this.items.length = 0;
+    }
+  }
+
+  createPlaylist_() {
+    const playlist = this.player_.playlist() || [];
+    let list = this.el_.querySelector('.vjs-playlist-item-list');
+    let overlay = this.el_.querySelector('.vjs-playlist-ad-overlay');
+
+    if (!list) {
+      list = document.createElement('ol');
+      list.className = 'vjs-playlist-item-list';
+      this.el_.appendChild(list);
+    }
+
+    this.empty_();
+
+    // create new items
+    for (let i = 0; i < playlist.length; i++) {
+      const item = new PlaylistMenuItem(this.player_, {
+        item: playlist[i]
+      }, this.options_);
+
+      this.items.push(item);
+      list.appendChild(item.el_);
+    }
+
+    // Inject the ad overlay. We use this element to block clicks during ad
+    // playback and darken the menu to indicate inactivity
+    if (!overlay) {
+      overlay = document.createElement('li');
+      overlay.className = 'vjs-playlist-ad-overlay';
+      list.appendChild(overlay);
+    } else {
+      // Move overlay to end of list
+      list.appendChild(overlay);
+    }
+
+    // select the current playlist item
+    const selectedIndex = this.player_.playlist.currentItem();
+
+    if (this.items.length && selectedIndex >= 0) {
+      addSelectedClass(this.items[selectedIndex]);
+
+      const thumbnail = this.items[selectedIndex].$('.vjs-playlist-thumbnail');
+
+      if (thumbnail) {
+        videojs.dom.addClass(thumbnail, 'vjs-playlist-now-playing');
+      }
+    }
+  }
+
+  update() {
+    // replace the playlist items being displayed, if necessary
+    const playlist = this.player_.playlist();
+
+    if (this.items.length !== playlist.length) {
+      // if the menu is currently empty or the state is obviously out
+      // of date, rebuild everything.
+      this.createPlaylist_();
+      return;
+    }
+
+    for (let i = 0; i < this.items.length; i++) {
+      if (this.items[i].item !== playlist[i]) {
+        // if any of the playlist items have changed, rebuild the
+        // entire playlist
+        this.createPlaylist_();
+        return;
+      }
+    }
+
+    // the playlist itself is unchanged so just update the selection
+    const currentItem = this.player_.playlist.currentItem();
+
+    for (let i = 0; i < this.items.length; i++) {
+      const item = this.items[i];
+
+      if (i === currentItem) {
+        addSelectedClass(item);
+        if (document.activeElement !== item.el()) {
+          videojs.dom.addClass(item.thumbnail, 'vjs-playlist-now-playing');
+        }
+        notUpNext(item);
+      } else if (i === currentItem + 1) {
+        removeSelectedClass(item);
+        upNext(item);
+      } else {
+        removeSelectedClass(item);
+        notUpNext(item);
+      }
+    }
+  }
+}
+
+videojs.registerComponent('PlaylistMenu', PlaylistMenu);
+
+export default PlaylistMenu;

--- a/src/playlist-menu.js
+++ b/src/playlist-menu.js
@@ -52,18 +52,7 @@ class PlaylistMenu extends Component {
     }
 
     this.on(player, ['loadstart', 'playlistchange', 'playlistsorted'], (e) => {
-
-      // The playlistadd and playlistremove events are handled separately. These
-      // also fire the playlistchange event with an `action` property, so can
-      // exclude them here.
-      if (e.type === 'playlistchange' && ['add', 'remove'].includes(e.action)) {
-        return;
-      }
       this.update();
-    });
-
-    this.on(player, ['playlistadd', 'playlistremove'], (e) => {
-
     });
 
     // Keep track of whether an ad is playing so that the menu

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -96,16 +96,12 @@ class PlaylistUI extends Plugin {
    */
   findRoot_(className) {
     const all = document.querySelectorAll('.' + className);
-    let el;
 
     for (let i = 0; i < all.length; i++) {
       if (!this.hasChildEls_(all[i])) {
-        el = all[i];
-        break;
+        return all[i];
       }
     }
-
-    return el;
   }
 }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,10 +1,7 @@
 import document from 'global/document';
 import videojs from 'video.js';
 import {version as VERSION} from '../package.json';
-
-const dom = videojs.dom;
-const merge = videojs.obj ? videojs.obj.merge : videojs.mergeOptions;
-const formatTime = videojs.time ? videojs.time.formatTime : videojs.formatTime;
+import PlaylistMenu from './playlist-menu';
 
 // see https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css/pointerevents.js
 const supportsCssPointerEvents = (() => {
@@ -20,395 +17,7 @@ const defaults = {
   supportsCssPointerEvents
 };
 
-// we don't add `vjs-playlist-now-playing` in addSelectedClass
-// so it won't conflict with `vjs-icon-play
-// since it'll get added when we mouse out
-const addSelectedClass = function(el) {
-  el.addClass('vjs-selected');
-};
-const removeSelectedClass = function(el) {
-  el.removeClass('vjs-selected');
-
-  if (el.thumbnail) {
-    dom.removeClass(el.thumbnail, 'vjs-playlist-now-playing');
-  }
-};
-
-const upNext = function(el) {
-  el.addClass('vjs-up-next');
-};
-const notUpNext = function(el) {
-  el.removeClass('vjs-up-next');
-};
-
-const createThumbnail = function(thumbnail) {
-  if (!thumbnail) {
-    const placeholder = document.createElement('div');
-
-    placeholder.className = 'vjs-playlist-thumbnail vjs-playlist-thumbnail-placeholder';
-    return placeholder;
-  }
-
-  const picture = document.createElement('picture');
-
-  picture.className = 'vjs-playlist-thumbnail';
-
-  if (typeof thumbnail === 'string') {
-    // simple thumbnails
-    const img = document.createElement('img');
-
-    img.loading = 'lazy';
-    img.src = thumbnail;
-    img.alt = '';
-    picture.appendChild(img);
-  } else {
-    // responsive thumbnails
-
-    // additional variations of a <picture> are specified as
-    // <source> elements
-    for (let i = 0; i < thumbnail.length - 1; i++) {
-      const variant = thumbnail[i];
-      const source = document.createElement('source');
-
-      // transfer the properties of each variant onto a <source>
-      for (const prop in variant) {
-        source[prop] = variant[prop];
-      }
-      picture.appendChild(source);
-    }
-
-    // the default version of a <picture> is specified by an <img>
-    const variant = thumbnail[thumbnail.length - 1];
-    const img = document.createElement('img');
-
-    img.loading = 'lazy';
-    img.alt = '';
-    for (const prop in variant) {
-      img[prop] = variant[prop];
-    }
-    picture.appendChild(img);
-  }
-  return picture;
-};
-
-const Component = videojs.getComponent('Component');
-
-class PlaylistMenuItem extends Component {
-
-  constructor(player, playlistItem, settings) {
-    if (!playlistItem.item) {
-      throw new Error('Cannot construct a PlaylistMenuItem without an item option');
-    }
-
-    playlistItem.showDescription = settings.showDescription;
-    super(player, playlistItem);
-    this.item = playlistItem.item;
-
-    this.playOnSelect = settings.playOnSelect;
-
-    this.emitTapEvents();
-
-    this.on(['click', 'tap'], this.switchPlaylistItem_);
-    this.on('keydown', this.handleKeyDown_);
-
-  }
-
-  handleKeyDown_(event) {
-    // keycode 13 is <Enter>
-    // keycode 32 is <Space>
-    if (event.which === 13 || event.which === 32) {
-      this.switchPlaylistItem_();
-    }
-  }
-
-  switchPlaylistItem_(event) {
-    this.player_.playlist.currentItem(this.player_.playlist().indexOf(this.item));
-    if (this.playOnSelect) {
-      this.player_.play();
-    }
-  }
-
-  createEl() {
-    const li = document.createElement('li');
-    const item = this.options_.item;
-    const showDescription = this.options_.showDescription;
-
-    if (typeof item.data === 'object') {
-      const dataKeys = Object.keys(item.data);
-
-      dataKeys.forEach(key => {
-        const value = item.data[key];
-
-        li.dataset[key] = value;
-      });
-    }
-
-    li.className = 'vjs-playlist-item';
-    li.setAttribute('tabIndex', 0);
-
-    // Thumbnail image
-    this.thumbnail = createThumbnail(item.thumbnail);
-    li.appendChild(this.thumbnail);
-
-    // Duration
-    if (item.duration) {
-      const duration = document.createElement('time');
-      const time = formatTime(item.duration);
-
-      duration.className = 'vjs-playlist-duration';
-      duration.setAttribute('datetime', 'PT0H0M' + item.duration + 'S');
-      duration.appendChild(document.createTextNode(time));
-      li.appendChild(duration);
-    }
-
-    // Now playing
-    const nowPlayingEl = document.createElement('span');
-    const nowPlayingText = this.localize('Now Playing');
-
-    nowPlayingEl.className = 'vjs-playlist-now-playing-text';
-    nowPlayingEl.appendChild(document.createTextNode(nowPlayingText));
-    nowPlayingEl.setAttribute('title', nowPlayingText);
-    this.thumbnail.appendChild(nowPlayingEl);
-
-    // Title container contains title and "up next"
-    const titleContainerEl = document.createElement('div');
-
-    titleContainerEl.className = 'vjs-playlist-title-container';
-    this.thumbnail.appendChild(titleContainerEl);
-
-    // Up next
-    const upNextEl = document.createElement('span');
-    const upNextText = this.localize('Up Next');
-
-    upNextEl.className = 'vjs-up-next-text';
-    upNextEl.appendChild(document.createTextNode(upNextText));
-    upNextEl.setAttribute('title', upNextText);
-    titleContainerEl.appendChild(upNextEl);
-
-    // Video title
-    const titleEl = document.createElement('cite');
-    const titleText = item.name || this.localize('Untitled Video');
-
-    titleEl.className = 'vjs-playlist-name';
-    titleEl.appendChild(document.createTextNode(titleText));
-    titleEl.setAttribute('title', titleText);
-    titleContainerEl.appendChild(titleEl);
-
-    // Populate thumbnails alt with the video title
-    this.thumbnail.getElementsByTagName('img').alt = titleText;
-
-    // We add thumbnail video description only if specified in playlist options
-    if (showDescription) {
-      const descriptionEl = document.createElement('div');
-      const descriptionText = item.description || '';
-
-      descriptionEl.className = 'vjs-playlist-description';
-      descriptionEl.appendChild(document.createTextNode(descriptionText));
-      descriptionEl.setAttribute('title', descriptionText);
-      titleContainerEl.appendChild(descriptionEl);
-    }
-
-    return li;
-  }
-}
-
-class PlaylistMenu extends Component {
-
-  constructor(player, options) {
-    if (!player.playlist) {
-      throw new Error('videojs-playlist is required for the playlist component');
-    }
-
-    super(player, options);
-    this.items = [];
-
-    if (options.horizontal) {
-      this.addClass('vjs-playlist-horizontal');
-    } else {
-      this.addClass('vjs-playlist-vertical');
-    }
-
-    // If CSS pointer events aren't supported, we have to prevent
-    // clicking on playlist items during ads with slightly more
-    // invasive techniques. Details in the stylesheet.
-    if (options.supportsCssPointerEvents) {
-      this.addClass('vjs-csspointerevents');
-    }
-
-    this.createPlaylist_();
-
-    if (!videojs.browser.TOUCH_ENABLED) {
-      this.addClass('vjs-mouse');
-    }
-
-    this.on(player, ['loadstart', 'playlistchange', 'playlistsorted'], (event) => {
-      this.update();
-    });
-
-    // Keep track of whether an ad is playing so that the menu
-    // appearance can be adapted appropriately
-    this.on(player, 'adstart', () => {
-      this.addClass('vjs-ad-playing');
-    });
-
-    this.on(player, 'adend', () => {
-      this.removeClass('vjs-ad-playing');
-    });
-
-    this.on('dispose', () => {
-      this.empty_();
-      player.playlistMenu = null;
-    });
-
-    this.on(player, 'dispose', () => {
-      this.dispose();
-    });
-  }
-
-  createEl() {
-    return dom.createEl('div', {className: this.options_.className});
-  }
-
-  empty_() {
-    if (this.items && this.items.length) {
-      this.items.forEach(i => i.dispose());
-      this.items.length = 0;
-    }
-  }
-
-  createPlaylist_() {
-    const playlist = this.player_.playlist() || [];
-    let list = this.el_.querySelector('.vjs-playlist-item-list');
-    let overlay = this.el_.querySelector('.vjs-playlist-ad-overlay');
-
-    if (!list) {
-      list = document.createElement('ol');
-      list.className = 'vjs-playlist-item-list';
-      this.el_.appendChild(list);
-    }
-
-    this.empty_();
-
-    // create new items
-    for (let i = 0; i < playlist.length; i++) {
-      const item = new PlaylistMenuItem(this.player_, {
-        item: playlist[i]
-      }, this.options_);
-
-      this.items.push(item);
-      list.appendChild(item.el_);
-    }
-
-    // Inject the ad overlay. We use this element to block clicks during ad
-    // playback and darken the menu to indicate inactivity
-    if (!overlay) {
-      overlay = document.createElement('li');
-      overlay.className = 'vjs-playlist-ad-overlay';
-      list.appendChild(overlay);
-    } else {
-      // Move overlay to end of list
-      list.appendChild(overlay);
-    }
-
-    // select the current playlist item
-    const selectedIndex = this.player_.playlist.currentItem();
-
-    if (this.items.length && selectedIndex >= 0) {
-      addSelectedClass(this.items[selectedIndex]);
-
-      const thumbnail = this.items[selectedIndex].$('.vjs-playlist-thumbnail');
-
-      if (thumbnail) {
-        dom.addClass(thumbnail, 'vjs-playlist-now-playing');
-      }
-    }
-  }
-
-  update() {
-    // replace the playlist items being displayed, if necessary
-    const playlist = this.player_.playlist();
-
-    if (this.items.length !== playlist.length) {
-      // if the menu is currently empty or the state is obviously out
-      // of date, rebuild everything.
-      this.createPlaylist_();
-      return;
-    }
-
-    for (let i = 0; i < this.items.length; i++) {
-      if (this.items[i].item !== playlist[i]) {
-        // if any of the playlist items have changed, rebuild the
-        // entire playlist
-        this.createPlaylist_();
-        return;
-      }
-    }
-
-    // the playlist itself is unchanged so just update the selection
-    const currentItem = this.player_.playlist.currentItem();
-
-    for (let i = 0; i < this.items.length; i++) {
-      const item = this.items[i];
-
-      if (i === currentItem) {
-        addSelectedClass(item);
-        if (document.activeElement !== item.el()) {
-          dom.addClass(item.thumbnail, 'vjs-playlist-now-playing');
-        }
-        notUpNext(item);
-      } else if (i === currentItem + 1) {
-        removeSelectedClass(item);
-        upNext(item);
-      } else {
-        removeSelectedClass(item);
-        notUpNext(item);
-      }
-    }
-  }
-}
-
-/**
- * Returns a boolean indicating whether an element has child elements.
- *
- * Note that this is distinct from whether it has child _nodes_.
- *
- * @param  {HTMLElement} el
- *         A DOM element.
- *
- * @return {boolean}
- *         Whether the element has child elements.
- */
-const hasChildEls = (el) => {
-  for (let i = 0; i < el.childNodes.length; i++) {
-    if (dom.isEl(el.childNodes[i])) {
-      return true;
-    }
-  }
-  return false;
-};
-
-/**
- * Finds the first empty root element.
- *
- * @param  {string} className
- *         An HTML class name to search for.
- *
- * @return {HTMLElement}
- *         A DOM element to use as the root for a playlist.
- */
-const findRoot = (className) => {
-  const all = document.querySelectorAll('.' + className);
-  let el;
-
-  for (let i = 0; i < all.length; i++) {
-    if (!hasChildEls(all[i])) {
-      el = all[i];
-      break;
-    }
-  }
-
-  return el;
-};
+const Plugin = videojs.getPlugin('plugin');
 
 /**
  * Initialize the plugin on a player.
@@ -426,57 +35,82 @@ const findRoot = (className) => {
  *         If true, will attempt to begin playback upon selecting a new
  *         playlist item in the UI.
  */
-const playlistUi = function(options) {
-  const player = this;
+class PlaylistUI extends Plugin {
 
-  if (!player.playlist) {
-    throw new Error('videojs-playlist plugin is required by the videojs-playlist-ui plugin');
-  }
+  constructor(player, options) {
+    super(player, options);
 
-  options = merge(defaults, options);
-
-  // If the player is already using this plugin, remove the pre-existing
-  // PlaylistMenu, but retain the element and its location in the DOM because
-  // it will be re-used.
-  if (player.playlistMenu) {
-    const el = player.playlistMenu.el();
-
-    // Catch cases where the menu may have been disposed elsewhere or the
-    // element removed from the DOM.
-    if (el) {
-      const parentNode = el.parentNode;
-      const nextSibling = el.nextSibling;
-
-      // Disposing the menu will remove `el` from the DOM, but we need to
-      // empty it ourselves to be sure.
-      player.playlistMenu.dispose();
-      dom.emptyEl(el);
-
-      // Put the element back in its place.
-      if (nextSibling) {
-        parentNode.insertBefore(el, nextSibling);
-      } else {
-        parentNode.appendChild(el);
-      }
-
-      options.el = el;
+    if (!player.usingPlugin('playlist')) {
+      player.log.error('videojs-playlist plugin is required by the videojs-playlist-ui plugin');
+      return;
     }
+
+    options = this.options_ = videojs.obj.merge(defaults, options);
+
+    if (!videojs.dom.isEl(options.el)) {
+      options.el = this.findRoot_(options.className);
+    }
+
+    // Expose the playlist menu component on the player as well as the plugin
+    // This is a bit of an anti-pattern, but it's been that way forever and
+    // there are likely to be integrations relying on it.
+    this.playlistMenu = player.playlistMenu = new PlaylistMenu(player, options);
   }
 
-  if (!dom.isEl(options.el)) {
-    options.el = findRoot(options.className);
+  /**
+   * Dispose the plugin.
+   */
+  dispose() {
+    super.dispose();
+    this.playlistMenu.dispose();
   }
 
-  player.playlistMenu = new PlaylistMenu(player, options);
-};
+  /**
+   * Returns a boolean indicating whether an element has child elements.
+   *
+   * Note that this is distinct from whether it has child _nodes_.
+   *
+   * @param  {HTMLElement} el
+   *         A DOM element.
+   *
+   * @return {boolean}
+   *         Whether the element has child elements.
+   */
+  hasChildEls_(el) {
+    for (let i = 0; i < el.childNodes.length; i++) {
+      if (videojs.dom.isEl(el.childNodes[i])) {
+        return true;
+      }
+    }
+    return false;
+  }
 
-// register components
-videojs.registerComponent('PlaylistMenu', PlaylistMenu);
-videojs.registerComponent('PlaylistMenuItem', PlaylistMenuItem);
+  /**
+   * Finds the first empty root element.
+   *
+   * @param  {string} className
+   *         An HTML class name to search for.
+   *
+   * @return {HTMLElement}
+   *         A DOM element to use as the root for a playlist.
+   */
+  findRoot_(className) {
+    const all = document.querySelectorAll('.' + className);
+    let el;
 
-// register the plugin
-videojs.registerPlugin('playlistUi', playlistUi);
+    for (let i = 0; i < all.length; i++) {
+      if (!this.hasChildEls_(all[i])) {
+        el = all[i];
+        break;
+      }
+    }
 
-playlistUi.VERSION = VERSION;
+    return el;
+  }
+}
 
-export default playlistUi;
+videojs.registerPlugin('playlistUi', PlaylistUI);
+
+PlaylistUI.VERSION = VERSION;
+
+export default PlaylistUI;

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -2,6 +2,7 @@
 import document from 'global/document';
 import window from 'global/window';
 import QUnit from 'qunit';
+import sinon from 'sinon';
 import videojs from 'video.js';
 
 import 'videojs-playlist';
@@ -34,7 +35,6 @@ const resolveUrl = url => {
   return a.href;
 };
 
-const dom = videojs.dom || videojs;
 const Html5 = videojs.getTech('Html5');
 
 QUnit.test('the environment is sane', function(assert) {
@@ -42,10 +42,8 @@ QUnit.test('the environment is sane', function(assert) {
 });
 
 function setup() {
-  const merge = videojs.obj ? videojs.obj.merge : videojs.mergeOptions;
-
   this.oldVideojsBrowser = videojs.browser;
-  videojs.browser = merge({}, videojs.browser);
+  videojs.browser = videojs.obj.merge({}, videojs.browser);
 
   this.fixture = document.querySelector('#qunit-fixture');
 
@@ -65,8 +63,8 @@ function setup() {
   this.player = videojs(video);
 
   // Create two playlist container elements.
-  this.fixture.appendChild(dom.createEl('div', {className: 'vjs-playlist'}));
-  this.fixture.appendChild(dom.createEl('div', {className: 'vjs-playlist'}));
+  this.fixture.appendChild(videojs.dom.createEl('div', {className: 'vjs-playlist'}));
+  this.fixture.appendChild(videojs.dom.createEl('div', {className: 'vjs-playlist'}));
 }
 
 function teardown() {
@@ -74,7 +72,7 @@ function teardown() {
   Html5.isSupported = this.realIsHtmlSupported;
   this.player.dispose();
   this.player = null;
-  dom.emptyEl(this.fixture);
+  videojs.dom.emptyEl(this.fixture);
 }
 
 QUnit.module('videojs-playlist-ui', {beforeEach: setup, afterEach: teardown});
@@ -84,10 +82,12 @@ QUnit.test('registers itself', function(assert) {
 });
 
 QUnit.test('errors if used without the playlist plugin', function(assert) {
-  assert.throws(function() {
-    this.player.playlist = null;
-    this.player.playlistUi();
-  }, 'threw on init');
+  sinon.spy(this.player.log, 'error');
+
+  this.player.playlist = null;
+  this.player.playlistUi();
+
+  assert.ok(this.player.log.error.calledOnce, 'player.log.error was called');
 });
 
 QUnit.test('is empty if the playlist plugin isn\'t initialized', function(assert) {
@@ -100,7 +100,7 @@ QUnit.test('is empty if the playlist plugin isn\'t initialized', function(assert
 });
 
 QUnit.test('can be initialized with an element', function(assert) {
-  const elem = dom.createEl('div');
+  const elem = videojs.dom.createEl('div');
 
   this.player.playlist(playlist);
   this.player.playlistUi({el: elem});
@@ -118,7 +118,7 @@ QUnit.test('can look for an element with the class "vjs-playlist" that is not al
 
   // Give the firstEl a child, so the plugin thinks it is in use and moves on
   // to the next one.
-  firstEl.appendChild(dom.createEl('div'));
+  firstEl.appendChild(videojs.dom.createEl('div'));
 
   this.player.playlist(playlist);
   this.player.playlistUi();
@@ -132,12 +132,12 @@ QUnit.test('can look for an element with the class "vjs-playlist" that is not al
 });
 
 QUnit.test('can look for an element with a custom class that is not already in use', function(assert) {
-  const firstEl = dom.createEl('div', {className: 'super-playlist'});
-  const secondEl = dom.createEl('div', {className: 'super-playlist'});
+  const firstEl = videojs.dom.createEl('div', {className: 'super-playlist'});
+  const secondEl = videojs.dom.createEl('div', {className: 'super-playlist'});
 
   // Give the firstEl a child, so the plugin thinks it is in use and moves on
   // to the next one.
-  firstEl.appendChild(dom.createEl('div'));
+  firstEl.appendChild(videojs.dom.createEl('div'));
 
   this.fixture.appendChild(firstEl);
   this.fixture.appendChild(secondEl);


### PR DESCRIPTION
## Description
This converts the plugin to a class-based plugin and moves the two components into their own files.

BREAKING CHANGES: Reimplements the plugin as a class-based plugin. Likely a non-breaking change for simple implementations, but this does change how things work if the plugin is re-initialized.

## Specific Changes proposed
- Converts code in `plugin.js` into a plugin class
- Moves components into their own files
- No longer throws when initialized without the videojs-playlist plugin - simply logs an error

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [x] Reviewed by Two Core Contributors
