### PR TITLE
feat: support playlistadd and playlistremove events

### DIFF
--- a/src/playlist-menu.js
+++ b/src/playlist-menu.js
@@ -158,16 +158,25 @@ class PlaylistMenu extends Component {
    */
   addItems_(index, count) {
     const playlist = this.player_.playlist();
-    const items = playlist.slice(index, count);
+    const items = playlist.slice(index, count + index);
 
     if (!items.length) {
       return;
     }
 
-    const menuItems = items.map(i => {
-      return new PlaylistMenuItem(this.player_, {
-        item: playlist[i]
-      }, this.options_);
+    const listEl = this.el_.querySelector('.vjs-playlist-item-list');
+    const listNodes = this.el_.querySelectorAll('.vjs-playlist-item');
+
+    // When appending to the list, `insertBefore` will only reliably accept
+    // `null` as the second argument, so we need to explicitly fall back to it.
+    const refNode = listNodes[index] || null;
+
+    const menuItems = items.map((item, i) => {
+      const menuItem = new PlaylistMenuItem(this.player_, {item}, this.options_);
+
+      listEl.insertBefore(menuItem.el_, refNode);
+
+      return menuItem;
     });
 
     this.items.splice(index, 0, ...menuItems);
@@ -185,7 +194,7 @@ class PlaylistMenu extends Component {
    *         THe number of items to remove.
    */
   removeItems_(index, count) {
-    const components = this.items.slice(index, count);
+    const components = this.items.slice(index, count + index);
 
     if (!components.length) {
       return;

--- a/src/playlist-menu.js
+++ b/src/playlist-menu.js
@@ -154,7 +154,7 @@ class PlaylistMenu extends Component {
    *         The index at which to start adding items.
    *
    * @param  {number} count
-   *         THe number of items to add.
+   *         The number of items to add.
    */
   addItems_(index, count) {
     const playlist = this.player_.playlist();
@@ -171,7 +171,7 @@ class PlaylistMenu extends Component {
     // `null` as the second argument, so we need to explicitly fall back to it.
     const refNode = listNodes[index] || null;
 
-    const menuItems = items.map((item, i) => {
+    const menuItems = items.map((item) => {
       const menuItem = new PlaylistMenuItem(this.player_, {item}, this.options_);
 
       listEl.insertBefore(menuItem.el_, refNode);
@@ -191,7 +191,7 @@ class PlaylistMenu extends Component {
    *         The index at which to start removing items.
    *
    * @param  {number} count
-   *         THe number of items to remove.
+   *         The number of items to remove.
    */
   removeItems_(index, count) {
     const components = this.items.slice(index, count + index);

--- a/src/playlist-menu.js
+++ b/src/playlist-menu.js
@@ -52,8 +52,18 @@ class PlaylistMenu extends Component {
     }
 
     this.on(player, ['loadstart', 'playlistchange', 'playlistsorted'], (e) => {
+
+      // The playlistadd and playlistremove events are handled separately. These
+      // also fire the playlistchange event with an `action` property, so can
+      // exclude them here.
+      if (e.type === 'playlistchange' && ['add', 'remove'].includes(e.action)) {
+        return;
+      }
       this.update();
     });
+
+    this.on(player, ['playlistadd'], (e) => this.addItems_(e.index, e.count));
+    this.on(player, ['playlistremove'], (e) => this.removeItems_(e.index, e.count));
 
     // Keep track of whether an ad is playing so that the menu
     // appearance can be adapted appropriately
@@ -132,6 +142,57 @@ class PlaylistMenu extends Component {
         videojs.dom.addClass(thumbnail, 'vjs-playlist-now-playing');
       }
     }
+  }
+
+  /**
+   * Adds a number of playlist items to the UI.
+   *
+   * Each item that was added to the underlying playlist in a certain range
+   * has a new PlaylistMenuItem created for it.
+   *
+   * @param  {number} index
+   *         The index at which to start adding items.
+   *
+   * @param  {number} count
+   *         THe number of items to add.
+   */
+  addItems_(index, count) {
+    const playlist = this.player_.playlist();
+    const items = playlist.slice(index, count);
+
+    if (!items.length) {
+      return;
+    }
+
+    const menuItems = items.map(i => {
+      return new PlaylistMenuItem(this.player_, {
+        item: playlist[i]
+      }, this.options_);
+    });
+
+    this.items.splice(index, 0, ...menuItems);
+  }
+
+  /**
+   * Removes a number of playlist items from the UI.
+   *
+   * Each PlaylistMenuItem component is disposed properly.
+   *
+   * @param  {number} index
+   *         The index at which to start removing items.
+   *
+   * @param  {number} count
+   *         THe number of items to remove.
+   */
+  removeItems_(index, count) {
+    const components = this.items.slice(index, count);
+
+    if (!components.length) {
+      return;
+    }
+
+    components.forEach(c => c.dispose());
+    this.items.splice(index, count);
   }
 
   update() {

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -631,3 +631,239 @@ QUnit.test('disposing the player also disposes the playlist menu', function(asse
   assert.strictEqual(this.fixture.querySelectorAll('.vjs-playlist').length, 1, 'only the unused playlist container is left');
   assert.strictEqual(this.player.playlistMenu, null, 'the playlistMenu property is null');
 });
+
+QUnit.module('videojs-playlist-ui: add/remove', {beforeEach: setup, afterEach: teardown});
+
+QUnit.test('adding zero items at the start of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add([], 0);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+  assert.strictEqual(items.length, playlist.length, 'correct number of items');
+});
+
+QUnit.test('adding one item at the start of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add({name: 'Test 1'}, 0);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+  assert.strictEqual(items.length, 3, 'correct number of items');
+  assert.strictEqual(items[0].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'has the correct name in the playlist DOM');
+});
+
+QUnit.test('adding two items at the start of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add([{name: 'Test 1'}, {name: 'Test 2'}], 0);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+  assert.strictEqual(items.length, 4, 'correct number of items');
+  assert.strictEqual(items[0].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'has the correct name in the playlist DOM');
+  assert.strictEqual(items[1].querySelector('.vjs-playlist-name').textContent, 'Test 2', 'has the correct name in the playlist DOM');
+});
+
+QUnit.test('adding one item in the middle of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add({name: 'Test 1'}, 1);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+  assert.strictEqual(items.length, 3, 'correct number of items');
+  assert.strictEqual(items[1].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'has the correct name in the playlist DOM');
+});
+
+QUnit.test('adding two items in the middle of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add([{name: 'Test 1'}, {name: 'Test 2'}], 1);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+  assert.strictEqual(items.length, 4, 'correct number of items');
+  assert.strictEqual(items[1].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'has the correct name in the playlist DOM');
+  assert.strictEqual(items[2].querySelector('.vjs-playlist-name').textContent, 'Test 2', 'has the correct name in the playlist DOM');
+});
+
+QUnit.test('adding one item at the end of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add({name: 'Test 1'}, playlist.length);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+  assert.strictEqual(items.length, 3, 'correct number of items');
+  assert.strictEqual(items[2].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'has the correct name in the playlist DOM');
+});
+
+QUnit.test('adding two items at the end of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add([{name: 'Test 1'}, {name: 'Test 2'}], playlist.length);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+  assert.strictEqual(items.length, 4, 'correct number of items');
+  assert.strictEqual(items[2].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'has the correct name in the playlist DOM');
+  assert.strictEqual(items[3].querySelector('.vjs-playlist-name').textContent, 'Test 2', 'has the correct name in the playlist DOM');
+});
+
+QUnit.test('removing zero items at the start of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.remove(0, 0);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+  assert.strictEqual(items.length, playlist.length, 'correct number of items');
+});
+
+QUnit.test('removing one item at the start of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add({name: 'Test 1'}, 0);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 3, 'correct number of items');
+
+  this.player.playlist.remove(0, 1);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'correct number of items');
+  assert.notStrictEqual(items[0].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'the added item was properly removed from the DOM');
+});
+
+QUnit.test('removing two items at the start of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add([{name: 'Test 1'}, {name: 'Test 2'}], 0);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 4, 'correct number of items');
+
+  this.player.playlist.remove(0, 2);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.notStrictEqual(items[0].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'the added item was properly removed from the DOM');
+  assert.notStrictEqual(items[1].querySelector('.vjs-playlist-name').textContent, 'Test 2', 'the added item was properly removed from the DOM');
+});
+
+QUnit.test('removing one item in the middle of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add({name: 'Test 1'}, 1);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 3, 'correct number of items');
+
+  this.player.playlist.remove(1, 1);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'correct number of items');
+  assert.notStrictEqual(items[1].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'the added item was properly removed from the DOM');
+});
+
+QUnit.test('removing two items in the middle of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add([{name: 'Test 1'}, {name: 'Test 2'}], 1);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 4, 'correct number of items');
+
+  this.player.playlist.remove(1, 2);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.notStrictEqual(items[1].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'the added item was properly removed from the DOM');
+  assert.strictEqual(items[2], undefined, 'the added item was properly removed from the DOM');
+});
+
+QUnit.test('removing one item at the end of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add({name: 'Test 1'}, 2);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 3, 'correct number of items');
+
+  this.player.playlist.remove(2, 1);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'correct number of items');
+  assert.notStrictEqual(items[1].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'the added item was properly removed from the DOM');
+});
+
+QUnit.test('removing two items at the end of the playlist', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  let items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'two items initially');
+
+  this.player.playlist.add([{name: 'Test 1'}, {name: 'Test 2'}], 2);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 4, 'correct number of items');
+
+  this.player.playlist.remove(2, 2);
+  items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(items.length, 2, 'correct number of items');
+  assert.notStrictEqual(items[1].querySelector('.vjs-playlist-name').textContent, 'Test 1', 'the added item was properly removed from the DOM');
+  assert.notStrictEqual(items[1].querySelector('.vjs-playlist-name').textContent, 'Test 2', 'the added item was properly removed from the DOM');
+});


### PR DESCRIPTION
## Description
Relates to https://github.com/videojs/videojs-playlist/pull/240

This adds support for dynamically adding/removing one or more items from the playlist UI.

Previously, the only way to change a playlist was to replace it entirely. This meant re-rendering the entire playlist UI if even a single item was added.

This isn't a major concern for a playlist of 3 or 5 or 10 items... but it is for playlists of 100 items or more. While this is an unusual use case, the ability to dynamically modify the contents of a playlist on a per-item basis makes sense.

## Specific Changes proposed
- Handles `playlistadd` and `playlistremove` events fired by the videojs-playlist plugin

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
