### PR TITLE
chore: do not run tests on npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "pretest": "npm-run-all lint build",
     "test": "karma start scripts/karma.conf.js",
     "update-changelog": "conventional-changelog -p videojs -i CHANGELOG.md -s",
-    "preversion": "npm test",
     "version": "is-prerelease || npm run update-changelog && git add CHANGELOG.md",
     "watch": "npm-run-all -p watch:*",
     "watch:css": "npm run build:css -- -w",


### PR DESCRIPTION
Very minor change to not run full test suite when running `npm version`.